### PR TITLE
fix Error: [$injector:strictdi] in strict mode

### DIFF
--- a/simple-modal.js
+++ b/simple-modal.js
@@ -61,6 +61,7 @@
 
                 controllerFn($scope);
             }
+            this.controller.$inject = ["$scope", "$element"];
             this.replace = false;
             this.transclude = true;
             this.template = `


### PR DESCRIPTION
When using ng-strict-di, opening the modal raises the error, because the controller is not using explicit annotation of the deps.

Fix #10