### PR TITLE
use umd wrapper

### DIFF
--- a/simple-modal.js
+++ b/simple-modal.js
@@ -1,12 +1,27 @@
-(function() {
+(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define(["exports"], factory);
+    } else if (typeof module === 'object' && module.exports) {
+        // Node. Does not work with strict CommonJS, but
+        // only CommonJS-like environments that support module.exports,
+        // like Node.
+        module.exports = factory();
+    } else {
+        // Browser globals (root is window)
+        root.returnExports = factory();
+    }
+}(this, function () {
     "use strict"
 
     var cachedCompileProvider;
-    angular.module('simple-modal', [])
-    .config(['$compileProvider', function($compileProvider){
-        cachedCompileProvider = $compileProvider;
-    }])
-    .factory('modalService', modalService);
+    const simpleModal = angular
+        .module('simple-modal', [])
+        .config(['$compileProvider', function($compileProvider){
+            cachedCompileProvider = $compileProvider;
+        }])
+        .factory('modalService', modalService)
+        .name;
 
     modalService.$inject = ['$rootScope', '$window', '$sce', '$compile'];
     function modalService($rootScope, $window, $sce, $compile) {
@@ -99,4 +114,6 @@
 
         return { open };
     }
-})();
+    
+    return simpleModal;
+}));


### PR DESCRIPTION
Using umd wrapper the lib is available in different contexts: AMD, CJS, global, ES6 module or with ES5 scripts tag
Ready to use, for instance, with webpack and rollup bundlers.

Fix #11